### PR TITLE
Fix: shortsComment update 쿼리문 수정

### DIFF
--- a/src/main/java/com/team1/spreet/repository/ShortsCommentRepository.java
+++ b/src/main/java/com/team1/spreet/repository/ShortsCommentRepository.java
@@ -17,7 +17,7 @@ public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Lo
     Optional<ShortsComment> findByIdAndIsDeletedFalse(Long shortsCommentId);
 
     @Modifying
-    @Query("update ShortsComment sc set sc.id = :shortsCommentId WHERE sc.isDeleted = true")
+    @Query("update ShortsComment sc set sc.isDeleted = true where sc.id = :shortsCommentId")
     void updateIsDeletedTrue(@Param("shortsCommentId") Long shortsCommentId);
 
     @Modifying


### PR DESCRIPTION
update 쿼리문에서 where절의 순서가 잘못되어 있어 shortsCommnet 삭제가 실행되지 않는 문제 발생.
쿼리문을 수정하여 해당 문제 해결.