### PR TITLE
fix: kako login

### DIFF
--- a/src/main/java/com/team1/spreet/controller/SocialLoginController.java
+++ b/src/main/java/com/team1/spreet/controller/SocialLoginController.java
@@ -28,7 +28,7 @@ public class SocialLoginController {
 	}
 
 	@ApiOperation(value = "카카오 로그인 API")
-	@PostMapping("/kakao/callback")
+	@GetMapping("/kakao/callback")
 	public CustomResponseBody kakaoLogin(@RequestParam @ApiParam(value = "로그인 코드") String code, HttpServletResponse httpServletResponse) throws JsonProcessingException {
 		return new CustomResponseBody<>(SuccessStatusCode.LOGIN_SUCCESS, kakaoLoginService.kakaoLogin(code, httpServletResponse));
 	}

--- a/src/main/java/com/team1/spreet/dto/UserDto.java
+++ b/src/main/java/com/team1/spreet/dto/UserDto.java
@@ -3,12 +3,13 @@ package com.team1.spreet.dto;
 import com.team1.spreet.entity.User;
 import com.team1.spreet.entity.UserRole;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public class UserDto {
@@ -65,10 +66,13 @@ public class UserDto {
         private String nickname;
         private String email;
 
-        public KakaoInfoDto(Long id, String nickname, String email) {
+        private String profileImage;
+
+        public KakaoInfoDto(Long id, String nickname, String email, String profileImage) {
             this.id = id;
             this.nickname = nickname;
             this.email = email;
+            this.profileImage = profileImage;
         }
     }
 

--- a/src/main/java/com/team1/spreet/entity/User.java
+++ b/src/main/java/com/team1/spreet/entity/User.java
@@ -62,7 +62,7 @@ public class User extends TimeStamped{
       프로필 사진 추가, 네이버 로그인 구현으로 인해 이 생성자는 불필요.
       카카오 로그인 코드 변경 후 삭제 필요!
      */
-    public User(Long kakaoId, String nickname, String password, String email) {
+/*    public User(Long kakaoId, String nickname, String password, String email) {
         this.loginId = kakaoId.toString();
         this.nickname = nickname;
         this.password = password;
@@ -70,7 +70,7 @@ public class User extends TimeStamped{
         this.userRole = UserRole.ROLE_USER;
         this.isDeleted = Boolean.FALSE;
         this.isCrew = Boolean.FALSE;
-    }
+    }*/
 
     public User(String socialId, String nickname, String password, String email, String profileImage) {
         this.loginId = socialId;

--- a/src/main/java/com/team1/spreet/service/KakaoLoginService.java
+++ b/src/main/java/com/team1/spreet/service/KakaoLoginService.java
@@ -102,12 +102,13 @@ public class KakaoLoginService {
         Long id = jsonNode.get("id").asLong();
         String nickname = jsonNode.get("properties").get("nickname").asText();
         String email = jsonNode.get("kakao_account").get("email").asText();
+        String profileImage = jsonNode.get("properties").get("profile_image").asText();
 
-        return new UserDto.KakaoInfoDto(id, nickname, email);
+        return new UserDto.KakaoInfoDto(id, nickname, email, profileImage);
     }
 
     private User registerKakaoUserIfNeeded(UserDto.KakaoInfoDto kakaoInfoDto) {
-        Long kakaoId = kakaoInfoDto.getId();
+        String kakaoId = kakaoInfoDto.getId().toString();
         User kakaoUser = userRepository.findByLoginId(kakaoId.toString()).orElse(null);
         if (kakaoUser == null) {
             String kakaoEmail = kakaoInfoDto.getEmail();
@@ -120,8 +121,8 @@ public class KakaoLoginService {
                 String encodedPassword = passwordEncoder.encode(password);
 
                 String email = kakaoInfoDto.getEmail();
-
-                kakaoUser = new User(kakaoId, kakaoInfoDto.getNickname(), encodedPassword, email);
+                String profileImage = kakaoInfoDto.getProfileImage();
+                kakaoUser = new User(kakaoId, kakaoInfoDto.getNickname(), encodedPassword, email, profileImage);
             }
 
             userRepository.save(kakaoUser);

--- a/src/main/java/com/team1/spreet/service/KakaoLoginService.java
+++ b/src/main/java/com/team1/spreet/service/KakaoLoginService.java
@@ -66,7 +66,7 @@ public class KakaoLoginService {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", "a2347db1ceee37de238b04db40b8bb4e");
-        body.add("redirect_url", "http://localhost:3000/api/user/kakao/callback");
+        body.add("redirect_url", "https://dev.d2hev55rb01409.amplifyapp.com/api/user/kakao/callback");
         body.add("code", code);
 
         //HTTP 요청 보내기

--- a/src/main/java/com/team1/spreet/service/KakaoLoginService.java
+++ b/src/main/java/com/team1/spreet/service/KakaoLoginService.java
@@ -9,12 +9,16 @@ import com.team1.spreet.entity.User;
 import com.team1.spreet.exception.SuccessStatusCode;
 import com.team1.spreet.jwt.JwtUtil;
 import com.team1.spreet.repository.UserRepository;
+import com.team1.spreet.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -44,8 +48,10 @@ public class KakaoLoginService {
         //3. 필요시에 회원가입
         User kakaoUser = registerKakaoUserIfNeeded(kakaoInfoDto);
 
-        //4. JWT 토큰 반환
-        String createToken = jwtUtil.createToken(kakaoUser.getId(), kakaoUser.getUserRole());
+        UserDetails kakaoUserDetails = new UserDetailsImpl(kakaoUser);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(kakaoUserDetails, null, kakaoUserDetails.getAuthorities());
+
+        String createToken = jwtUtil.createToken(authentication);
 
         httpServletResponse.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
     <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-        <webhookUri>https://hooks.slack.com/services/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</webhookUri>
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </layout>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,9 +3,9 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
     <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <webhookUri>https://hooks.slack.com/services/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</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </layout>
         <colorCoding>true</colorCoding>
     </appender>


### PR DESCRIPTION
1. 카카오 로그인시 프로필 이미지를 함께 받아옵니다.
2. 카카오 로그인을 PostMapping에서 GetMapping으로 변경하였습니다.
3. 프론트에서 리다이렉팅 url 변경을 요구하여서 요구한 프론트 배포 서버 주소로 redirecturl을 변경하였습니다.
4. 카카오 로그인시 Authentication을 사용하여 인증객체로 로그인하게끔 바꿔주었습니다.

논의 사항:
1. 카카오 프로필을 불러올 시 카카오에서 제공되는 사진 url으로 저장됩니다.
다른 이미지 파일들처럼 s3형식으로 저장을 해야될지 고민입니다.
2. getMapping으로 바꿔진 kakao login은 프론트와 함께 테스트를 해봐야할 것 같습니다.