### PR TITLE
Refactor: shorts 리팩토링 및 메인화면에서의 조회 기능 구현

### DIFF
--- a/src/main/java/com/team1/spreet/controller/ShortsCommentController.java
+++ b/src/main/java/com/team1/spreet/controller/ShortsCommentController.java
@@ -28,7 +28,8 @@ public class ShortsCommentController {
 	@PostMapping("/{shortsId}/comment")
 	public CustomResponseBody<SuccessStatusCode> saveShortsComment(@PathVariable @ApiParam(value = "댓글 등록할 쇼츠 ID") Long shortsId,
 		@RequestBody @Valid @ApiParam(value = "등록할 댓글 내용") ShortsCommentDto.RequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsCommentService.saveShortsComment(shortsId, requestDto, userDetails.getUser()));
+		shortsCommentService.saveShortsComment(shortsId, requestDto, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.SAVE_COMMENT);
 	}
 
 	// shortsComment 수정
@@ -36,7 +37,8 @@ public class ShortsCommentController {
 	@PutMapping("/comment/{shortsCommentId}")
 	public CustomResponseBody<SuccessStatusCode> updateShortsComment(@PathVariable @ApiParam(value = "댓글 수정할 쇼츠 ID") Long shortsCommentId,
 		@RequestBody @Valid @ApiParam(value = "수정할 댓글 정보") ShortsCommentDto.RequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsCommentService.updateShortsComment(shortsCommentId, requestDto, userDetails.getUser()));
+		shortsCommentService.updateShortsComment(shortsCommentId, requestDto, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.UPDATE_COMMENT);
 	}
 
 	// shortsComment 삭제
@@ -44,7 +46,8 @@ public class ShortsCommentController {
 	@DeleteMapping("/comment/{shortsCommentId}")
 	public CustomResponseBody<SuccessStatusCode> deleteShortsComment(@PathVariable @ApiParam(value = "댓글 삭제할 쇼츠 ID") Long shortsCommentId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsCommentService.deleteShortsComment(shortsCommentId, userDetails.getUser()));
+		shortsCommentService.deleteShortsComment(shortsCommentId, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.DELETE_COMMENT);
 	}
 
 	// shortsComment 조회

--- a/src/main/java/com/team1/spreet/controller/ShortsController.java
+++ b/src/main/java/com/team1/spreet/controller/ShortsController.java
@@ -27,17 +27,19 @@ public class ShortsController {
 	// shorts 등록
 	@ApiOperation(value = "쇼츠 등록 API")
 	@PostMapping
-	public CustomResponseBody<ShortsDto.ResponseDto> saveShorts(@ModelAttribute @Valid @ApiParam(value = "쇼츠 등록 정보") ShortsDto.RequestDto requestDto,
+	public CustomResponseBody<SuccessStatusCode> saveShorts(@ModelAttribute @Valid @ApiParam(value = "쇼츠 등록 정보") ShortsDto.RequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsService.saveShorts(requestDto, userDetails.getUser()));
+		shortsService.saveShorts(requestDto, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.SAVE_SHORTS);
 	}
 
 	// shorts 수정
 	@ApiOperation(value = "쇼츠 수정 API")
 	@PutMapping("/{shortsId}")
-	public CustomResponseBody<ShortsDto.ResponseDto> updateShorts(@ModelAttribute @Valid @ApiParam(value = "쇼츠 수정 정보") ShortsDto.UpdateRequestDto requestDto,
+	public CustomResponseBody<SuccessStatusCode> updateShorts(@ModelAttribute @Valid @ApiParam(value = "쇼츠 수정 정보") ShortsDto.UpdateRequestDto requestDto,
 		@PathVariable @ApiParam(value = "수정할 쇼츠 ID") Long shortsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsService.updateShorts(requestDto, shortsId, userDetails.getUser()));
+		shortsService.updateShorts(requestDto, shortsId, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.UPDATE_SHORTS);
 	}
 
 	// shorts 삭제
@@ -45,7 +47,8 @@ public class ShortsController {
 	@DeleteMapping("/{shortsId}")
 	public CustomResponseBody<SuccessStatusCode> deleteShorts(@PathVariable @ApiParam(value = "삭제할 쇼츠 ID") Long shortsId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(shortsService.deleteShorts(shortsId, userDetails.getUser()));
+		shortsService.deleteShorts(shortsId, userDetails.getUser());
+		return new CustomResponseBody<>(SuccessStatusCode.DELETE_SHORTS);
 	}
 
 	// shorts 상세조회
@@ -57,15 +60,26 @@ public class ShortsController {
 		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS, shortsService.getShorts(shortsId, userId));
 	}
 
-	// shorts 카테고리별 조회
+	// shorts 화면에서 카테고리별 조회
 	@ApiOperation(value = "쇼츠 카테고리별 조회 API")
 	@GetMapping
-	public CustomResponseBody<List<ShortsDto.ResponseDto>> getShortsByCategory
-		(@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category,
+	public CustomResponseBody<List<ShortsDto.ResponseDto>> getShortsByCategory(
+			@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category,
 			@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") int page,
-			@RequestParam(defaultValue = "10") @ApiParam(value = "조회할 사이즈") int size, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+			@RequestParam(defaultValue = "10") @ApiParam(value = "조회할 사이즈") int size,
+		    @AuthenticationPrincipal UserDetailsImpl userDetails) {
 		Long userId = userDetails == null ? 0L : userDetails.getUser().getId();
 		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getShortsByCategory(category, page, size, userId));
+	}
+
+	// 메인화면에서 카테고리별 조회
+	@ApiOperation(value = "메인 화면에서 카테고리별 조회 API")
+	@GetMapping("/main")
+	public CustomResponseBody<List<ShortsDto.SimpleResponseDto>> getSimpleShortsByCategory(
+		@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category,
+		@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") int page,
+		@RequestParam(defaultValue = "10") @ApiParam(value = "조회할 사이즈") int size) {
+		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getSimpleShortsByCategory(category, page, size));
 	}
 
 }

--- a/src/main/java/com/team1/spreet/controller/ShortsLikeController.java
+++ b/src/main/java/com/team1/spreet/controller/ShortsLikeController.java
@@ -26,6 +26,6 @@ public class ShortsLikeController {
 	@PostMapping("/{shortsId}")
 	public CustomResponseBody<ShortsLikeDto.ResponseDto> setShortsLike(@PathVariable @ApiParam(value = "좋아요 등록/취소 하기 위한 쇼츠 ID") Long shortsId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return shortsLikeService.setShortsLike(shortsId, userDetails);
+		return shortsLikeService.setShortsLike(shortsId, userDetails.getUser());
 	}
 }

--- a/src/main/java/com/team1/spreet/dto/ShortsDto.java
+++ b/src/main/java/com/team1/spreet/dto/ShortsDto.java
@@ -61,6 +61,37 @@ public class ShortsDto {
 
 	@NoArgsConstructor
 	@Getter
+	public static class SimpleResponseDto {
+		@ApiModelProperty(value = "쇼츠 ID")
+		private Long shortsId;
+
+		@ApiModelProperty(value = "닉네임")
+		private String nickname;
+
+		@ApiModelProperty(value = "제목")
+		private String title;
+
+		@ApiModelProperty(value = "영상 url")
+		private String videoUrl;
+
+		@ApiModelProperty(value = "카테고리")
+		private String category;
+
+		@ApiModelProperty(value = "프로필 이미지")
+		private String profileImageUrl;
+
+		public SimpleResponseDto(Shorts shorts) {
+			this.shortsId = shorts.getId();
+			this.nickname = shorts.getUser().getNickname();
+			this.title = shorts.getTitle();
+			this.videoUrl = shorts.getVideoUrl();
+			this.category = shorts.getCategory().value();
+			this.profileImageUrl = shorts.getUser().getProfileImage();
+		}
+	}
+
+	@NoArgsConstructor
+	@Getter
 	public static class ResponseDto {
 		@ApiModelProperty(value = "쇼츠 ID")
 		private Long shortsId;

--- a/src/main/java/com/team1/spreet/entity/Shorts.java
+++ b/src/main/java/com/team1/spreet/entity/Shorts.java
@@ -17,10 +17,12 @@ import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@DynamicUpdate
 public class Shorts extends TimeStamped {
 
     @Id
@@ -54,8 +56,7 @@ public class Shorts extends TimeStamped {
     @OneToMany(mappedBy = "shorts", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShortsComment> shortsCommentList = new ArrayList<>();  //쇼츠 코맨트 양방향
 
-    @OneToMany(mappedBy = "shorts", fetch = FetchType.LAZY, cascade = CascadeType.ALL
-            , orphanRemoval = true)
+    @OneToMany(mappedBy = "shorts", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShortsLike> shortsLikeList = new ArrayList<>();        //쇼츠 좋아요 양방향
 
     public Shorts(String title, String content, String videoUrl, Category category, User user) {
@@ -71,6 +72,10 @@ public class Shorts extends TimeStamped {
         this.content = content;
         this.videoUrl = videoUrl;
         this.category = category;
+    }
+
+    public void isDeleted() {
+        this.isDeleted = true;
     }
 
     public void addLike() {

--- a/src/main/java/com/team1/spreet/entity/ShortsComment.java
+++ b/src/main/java/com/team1/spreet/entity/ShortsComment.java
@@ -11,10 +11,12 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@DynamicUpdate
 public class ShortsComment extends TimeStamped {
 
     @Id
@@ -44,5 +46,9 @@ public class ShortsComment extends TimeStamped {
 
     public void updateShortsComment(String content) {
         this.content = content;
+    }
+
+    public void idDeleted() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/team1/spreet/repository/ShortsCommentRepository.java
+++ b/src/main/java/com/team1/spreet/repository/ShortsCommentRepository.java
@@ -15,12 +15,8 @@ public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Lo
         + "where sc.shorts.id = :shortsId and sc.isDeleted = false order by sc.createdAt desc")
     List<ShortsComment> findByShortsIdAndIsDeletedFalseWithUserOrderByCreatedAtDesc(@Param("shortsId") Long shortsId);
 
-    @Query("select sc from ShortsComment sc where sc.id = :shortsCommentId and sc.isDeleted = false")
-    Optional<ShortsComment> findByIdAndIsDeletedFalse(@Param("shortsCommentId") Long shortsCommentId);
-
-    @Modifying
-    @Query("update ShortsComment sc set sc.isDeleted = true where sc.id = :shortsCommentId")
-    void updateIsDeletedTrueById(@Param("shortsCommentId") Long shortsCommentId);
+    @Query("select distinct sc from ShortsComment sc join fetch sc.user where sc.id = :shortsCommentId and sc.isDeleted = false")
+    Optional<ShortsComment> findByIdAndIsDeletedFalseWithUser(@Param("shortsCommentId") Long shortsCommentId);
 
     @Transactional
     @Modifying

--- a/src/main/java/com/team1/spreet/repository/ShortsRepository.java
+++ b/src/main/java/com/team1/spreet/repository/ShortsRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,12 +13,10 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 	@Query("select s from Shorts s where s.id = :shortsId and s.isDeleted = false")
 	Optional<Shorts> findByIdAndIsDeletedFalse(@Param("shortsId")Long shortsId);
 
-	@Modifying
-	@Query("update Shorts s set s.isDeleted = true where s.id = :shortsId")
-	void updateIsDeletedTrueById(@Param("shortsId") Long shortsId);
+	@Query("select s from Shorts s join fetch s.user where s.id = :shortsId and s.isDeleted = false")
+	Optional<Shorts> findByIdAndIsDeletedFalseWithUser(@Param("shortsId")Long shortsId);
 
 	//카테고리별 조회
-	@Query("select s from Shorts s where s.category = :category and s.isDeleted = false")
-	Page<Shorts> findShortsByCategoryAndIsDeletedFalse(@Param("category")Category category, Pageable pageable);
+	Page<Shorts> findShortsByIsDeletedFalseAndCategory(@Param("category")Category category, Pageable pageable);
 
 }

--- a/src/main/java/com/team1/spreet/service/ShortsCommentService.java
+++ b/src/main/java/com/team1/spreet/service/ShortsCommentService.java
@@ -7,15 +7,13 @@ import com.team1.spreet.entity.User;
 import com.team1.spreet.entity.UserRole;
 import com.team1.spreet.exception.ErrorStatusCode;
 import com.team1.spreet.exception.RestApiException;
-import com.team1.spreet.exception.SuccessStatusCode;
 import com.team1.spreet.repository.ShortsCommentRepository;
 import com.team1.spreet.repository.ShortsRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,31 +24,29 @@ public class ShortsCommentService {
 	private final ShortsRepository shortsRepository;
 
 	// shortsComment 등록
-	public SuccessStatusCode saveShortsComment(Long shortsId, ShortsCommentDto.RequestDto requestDto, User user) {
+	public void saveShortsComment(Long shortsId, ShortsCommentDto.RequestDto requestDto, User user) {
 		Shorts shorts = checkShorts(shortsId);
 		shortsCommentRepository.saveAndFlush(requestDto.toEntity(shorts, user));
-
-		return SuccessStatusCode.SAVE_COMMENT;
 	}
 
 	// shortsComment 수정
-	public SuccessStatusCode updateShortsComment(Long shortsCommentId, ShortsCommentDto.RequestDto requestDto, User user) {
+	public void updateShortsComment(Long shortsCommentId, ShortsCommentDto.RequestDto requestDto, User user) {
 		ShortsComment shortsComment = checkShortsComment(shortsCommentId);
 
-		if (checkOwner(shortsComment, user.getId())) {
-			shortsComment.updateShortsComment(requestDto.getContent());
+		if (!user.getId().equals(shortsComment.getUser().getId())) {
+			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
-		return SuccessStatusCode.UPDATE_COMMENT;
+		shortsComment.updateShortsComment(requestDto.getContent());
 	}
 
 	// shortsComment 삭제
-	public SuccessStatusCode deleteShortsComment(Long shortsCommentId, User user) {
+	public void deleteShortsComment(Long shortsCommentId, User user) {
 		ShortsComment shortsComment = checkShortsComment(shortsCommentId);
 
-		if (user.getUserRole() == UserRole.ROLE_ADMIN || checkOwner(shortsComment, user.getId())) {
-			shortsCommentRepository.updateIsDeletedTrueById(shortsCommentId);
+		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.getId().equals(shortsComment.getUser().getId()) ) {
+			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
-		return SuccessStatusCode.DELETE_COMMENT;
+		shortsComment.idDeleted();
 	}
 
 	// shortsComment 조회
@@ -77,17 +73,8 @@ public class ShortsCommentService {
 
 	// shortsComment 가 존재하는지 확인
 	private ShortsComment checkShortsComment(Long shortsCommentId) {
-		return shortsCommentRepository.findByIdAndIsDeletedFalse(shortsCommentId).orElseThrow(
+		return shortsCommentRepository.findByIdAndIsDeletedFalseWithUser(shortsCommentId).orElseThrow(
 			() -> new RestApiException(ErrorStatusCode.NOT_EXIST_COMMENT)
 		);
 	}
-
-	// shortsComment 작성자가 user 와 일치하는지 확인
-	private boolean checkOwner(ShortsComment shortsComment, Long userId) {
-		if (!userId.equals(shortsComment.getUser().getId())) {
-			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
-		}
-		return true;
-	}
-
 }

--- a/src/main/java/com/team1/spreet/service/ShortsLikeService.java
+++ b/src/main/java/com/team1/spreet/service/ShortsLikeService.java
@@ -10,8 +10,6 @@ import com.team1.spreet.exception.RestApiException;
 import com.team1.spreet.exception.SuccessStatusCode;
 import com.team1.spreet.repository.ShortsLikeRepository;
 import com.team1.spreet.repository.ShortsRepository;
-import com.team1.spreet.repository.UserRepository;
-import com.team1.spreet.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,15 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShortsLikeService {
 	private final ShortsLikeRepository shortsLikeRepository;
 	private final ShortsRepository shortsRepository;
-	private final UserRepository userRepository;
-
 
 	// shortsLike 등록
-	public CustomResponseBody<ShortsLikeDto.ResponseDto> setShortsLike(Long shortsId, UserDetailsImpl userDetails) {
-		User user = userRepository.findById(userDetails.getUser().getId()).orElseThrow(
-			() -> new RestApiException(ErrorStatusCode.NOT_EXIST_USER)
-		);
-
+	public CustomResponseBody<ShortsLikeDto.ResponseDto> setShortsLike(Long shortsId, User user) {
 		Shorts shorts = checkShorts(shortsId);
 
 		ShortsLike findShortsLike = shortsLikeRepository.findByShortsIdAndUserIdAndIsDeletedFalse(shortsId, user.getId()).orElse(null);
@@ -44,7 +36,6 @@ public class ShortsLikeService {
 			shortsLikeRepository.save(shortsLike);
 			return new CustomResponseBody<>(SuccessStatusCode.LIKE, new ShortsLikeDto.ResponseDto(true));
 		}
-
 	}
 
 	// shorts 가 존재하는지 확인

--- a/src/main/java/com/team1/spreet/service/ShortsService.java
+++ b/src/main/java/com/team1/spreet/service/ShortsService.java
@@ -8,7 +8,6 @@ import com.team1.spreet.entity.User;
 import com.team1.spreet.entity.UserRole;
 import com.team1.spreet.exception.ErrorStatusCode;
 import com.team1.spreet.exception.RestApiException;
-import com.team1.spreet.exception.SuccessStatusCode;
 import com.team1.spreet.repository.ShortsCommentRepository;
 import com.team1.spreet.repository.ShortsLikeRepository;
 import com.team1.spreet.repository.ShortsRepository;
@@ -32,47 +31,45 @@ public class ShortsService {
 	private final ShortsCommentRepository shortsCommentRepository;
 
 	// shorts 등록
-	public SuccessStatusCode saveShorts(ShortsDto.RequestDto requestDto, User user) {
+	public void saveShorts(ShortsDto.RequestDto requestDto, User user) {
 		String videoUrl = awsS3Service.uploadFile(requestDto.getFile());
 
 		shortsRepository.saveAndFlush(requestDto.toEntity(videoUrl, user));
-
-		return SuccessStatusCode.SAVE_SHORTS;
 	}
 
 	// shorts 수정
-	public SuccessStatusCode updateShorts(ShortsDto.UpdateRequestDto requestDto, Long shortsId, User user) {
+	public void updateShorts(ShortsDto.UpdateRequestDto requestDto, Long shortsId, User user) {
 		Shorts shorts = checkShorts(shortsId);
-		String videoUrl;
-
-		if (checkOwner(shorts, user.getId())) {
-			if (!requestDto.getFile().isEmpty()) {
-				//첨부파일 수정시 기존 첨부파일 삭제
-				String fileName = shorts.getVideoUrl().split(".com/")[1];
-				awsS3Service.deleteFile(fileName);
-
-				//새로운 파일 업로드
-				videoUrl = awsS3Service.uploadFile(requestDto.getFile());
-			} else {
-				//첨부파일 수정 안함
-				videoUrl = shorts.getVideoUrl();
-			}
-			shorts.update(requestDto.getTitle(), requestDto.getContent(), videoUrl, requestDto.getCategory());
+		if (!user.getId().equals(shorts.getUser().getId())) {   // 수정하려는 유저가 작성자가 아닌 경우
+			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
-		return SuccessStatusCode.UPDATE_SHORTS;
+
+		String videoUrl;
+		if (!requestDto.getFile().isEmpty()) {
+			//첨부파일 수정시 기존 첨부파일 삭제
+			String fileName = shorts.getVideoUrl().split(".com/")[1];
+			awsS3Service.deleteFile(fileName);
+
+			//새로운 파일 업로드
+			videoUrl = awsS3Service.uploadFile(requestDto.getFile());
+		} else {
+			//첨부파일 수정 안함
+			videoUrl = shorts.getVideoUrl();
+		}
+		shorts.update(requestDto.getTitle(), requestDto.getContent(), videoUrl, requestDto.getCategory());
 	}
 
 
 	// shorts 삭제
-	public SuccessStatusCode deleteShorts(Long shortsId, User user) {
+	public void deleteShorts(Long shortsId, User user) {
 		Shorts shorts = checkShorts(shortsId);
-
-		if (user.getUserRole() == UserRole.ROLE_ADMIN || checkOwner(shorts, user.getId())) {
-			String fileName = shorts.getVideoUrl().split(".com/")[1];
-			awsS3Service.deleteFile(fileName);
-			deleteShortsById(shortsId);
+		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.getId().equals(shorts.getUser().getId())) {
+			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
-		return SuccessStatusCode.DELETE_SHORTS;
+
+		String fileName = shorts.getVideoUrl().split(".com/")[1];
+		awsS3Service.deleteFile(fileName);
+		deleteShortsById(shorts);
 	}
 
 	// shorts 상세조회
@@ -91,7 +88,7 @@ public class ShortsService {
 	@Transactional(readOnly = true)
 	public List<ShortsDto.ResponseDto> getShortsByCategory(Category category, int page, int size, Long userId) {
 		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-		List<Shorts> shortsByCategory = shortsRepository.findShortsByCategoryAndIsDeletedFalse(category, pageable).getContent();
+		List<Shorts> shortsByCategory = shortsRepository.findShortsByIsDeletedFalseAndCategory(category, pageable).getContent();
 
 		List<ShortsDto.ResponseDto> shortsList = new ArrayList<>();
 
@@ -107,6 +104,20 @@ public class ShortsService {
 		return shortsList;
 	}
 
+	// 메인화면에서 shorts 조회(페이징)
+	@Transactional(readOnly = true)
+	public List<ShortsDto.SimpleResponseDto> getSimpleShortsByCategory(Category category, int page, int size) {
+		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+		List<Shorts> shortsByCategory = shortsRepository.findShortsByIsDeletedFalseAndCategory(category, pageable).getContent();
+
+		List<ShortsDto.SimpleResponseDto> shortsList = new ArrayList<>();
+
+		for (Shorts shorts : shortsByCategory) {
+			shortsList.add(new ShortsDto.SimpleResponseDto(shorts));
+		}
+		return shortsList;
+	}
+
 	// user 가 해당 shorts 에 좋아요를 눌렀는지 확인
 	private boolean checkLike(Long shortsId, Long userId) {
 		ShortsLike shortsLike = shortsLikeRepository.findByShortsIdAndUserIdAndIsDeletedFalse(shortsId, userId)
@@ -116,23 +127,14 @@ public class ShortsService {
 
 	// shorts 가 존재하는지 확인
 	private Shorts checkShorts(Long shortsId) {
-		return shortsRepository.findByIdAndIsDeletedFalse(shortsId).orElseThrow(
+		return shortsRepository.findByIdAndIsDeletedFalseWithUser(shortsId).orElseThrow(
 			() -> new RestApiException(ErrorStatusCode.NOT_EXIST_SHORTS)
 		);
 	}
 
-	// shorts 작성자와 user 가 같은지 확인
-	private boolean checkOwner(Shorts shorts, Long userId) {
-		if (!shorts.getUser().getId().equals(userId)) {
-			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
-		}
-		return true;
+	private void deleteShortsById(Shorts shorts) {
+		shortsCommentRepository.updateIsDeletedTrueByShortsId(shorts.getId());
+		shortsLikeRepository.deleteByShortsId(shorts.getId());
+		shorts.isDeleted();
 	}
-
-	private void deleteShortsById(Long shortsId) {
-		shortsCommentRepository.updateIsDeletedTrueByShortsId(shortsId);
-		shortsLikeRepository.deleteByShortsId(shortsId);
-		shortsRepository.updateIsDeletedTrueById(shortsId);
-	}
-
 }


### PR DESCRIPTION
1. service단의 반환타입 변경 SuccessCode -> void
2. 쇼츠화면과 메인화면에서 카테고리별 조회를 위해 같은 API를 사용하고 있었지만, 메인화면에서는 불필요한 정보까지 포함되어있었기 때문에 별도의 API를 구현
3. soft delete의 구현을 위해 JPQL을 통한 update문을 사용하고 있었으나, @Dynamicupdate 어노테이션을 통해 select 없이 update 쿼리를 실행시킬 수 있도록 함(shorts, shortsComment class)
4. 수정,삭제 로직의 예외처리