### PR TITLE
Refactor: url 변경에 따른 코드 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/team1/spreet/controller/ShortsController.java
+++ b/src/main/java/com/team1/spreet/controller/ShortsController.java
@@ -66,20 +66,17 @@ public class ShortsController {
 	public CustomResponseBody<List<ShortsDto.ResponseDto>> getShortsByCategory(
 			@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category,
 			@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") int page,
-			@RequestParam(defaultValue = "10") @ApiParam(value = "조회할 사이즈") int size,
 		    @AuthenticationPrincipal UserDetailsImpl userDetails) {
 		Long userId = userDetails == null ? 0L : userDetails.getUser().getId();
-		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getShortsByCategory(category, page, size, userId));
+		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getShortsByCategory(category, page, userId));
 	}
 
 	// 메인화면에서 카테고리별 조회
 	@ApiOperation(value = "메인 화면에서 카테고리별 조회 API")
 	@GetMapping("/main")
 	public CustomResponseBody<List<ShortsDto.SimpleResponseDto>> getSimpleShortsByCategory(
-		@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category,
-		@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") int page,
-		@RequestParam(defaultValue = "10") @ApiParam(value = "조회할 사이즈") int size) {
-		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getSimpleShortsByCategory(category, page, size));
+		@RequestParam(value = "category") @ApiParam(value = "조회할 카테고리") Category category) {
+		return new CustomResponseBody<>(SuccessStatusCode.GET_SHORTS_BY_CATEGORY, shortsService.getSimpleShortsByCategory(category));
 	}
 
 }

--- a/src/main/java/com/team1/spreet/repository/ShortsRepository.java
+++ b/src/main/java/com/team1/spreet/repository/ShortsRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface ShortsRepository extends JpaRepository<Shorts, Long> {
+@Repository
+public interface ShortsRepository extends JpaRepository<Shorts, Long>, ShortsCustomRepository {
 	@Query("select s from Shorts s where s.id = :shortsId and s.isDeleted = false")
 	Optional<Shorts> findByIdAndIsDeletedFalse(@Param("shortsId")Long shortsId);
 

--- a/src/main/java/com/team1/spreet/service/ShortsCommentService.java
+++ b/src/main/java/com/team1/spreet/service/ShortsCommentService.java
@@ -33,7 +33,7 @@ public class ShortsCommentService {
 	public void updateShortsComment(Long shortsCommentId, ShortsCommentDto.RequestDto requestDto, User user) {
 		ShortsComment shortsComment = checkShortsComment(shortsCommentId);
 
-		if (!user.getId().equals(shortsComment.getUser().getId())) {
+		if (!user.equals(shortsComment.getUser())) {
 			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
 		shortsComment.updateShortsComment(requestDto.getContent());
@@ -43,7 +43,7 @@ public class ShortsCommentService {
 	public void deleteShortsComment(Long shortsCommentId, User user) {
 		ShortsComment shortsComment = checkShortsComment(shortsCommentId);
 
-		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.getId().equals(shortsComment.getUser().getId()) ) {
+		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.equals(shortsComment.getUser())) {
 			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
 		shortsComment.idDeleted();

--- a/src/main/java/com/team1/spreet/service/ShortsService.java
+++ b/src/main/java/com/team1/spreet/service/ShortsService.java
@@ -40,7 +40,7 @@ public class ShortsService {
 	// shorts 수정
 	public void updateShorts(ShortsDto.UpdateRequestDto requestDto, Long shortsId, User user) {
 		Shorts shorts = checkShorts(shortsId);
-		if (!user.getId().equals(shorts.getUser().getId())) {   // 수정하려는 유저가 작성자가 아닌 경우
+		if (!user.equals(shorts.getUser())) {   // 수정하려는 유저가 작성자가 아닌 경우
 			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
 
@@ -63,7 +63,7 @@ public class ShortsService {
 	// shorts 삭제
 	public void deleteShorts(Long shortsId, User user) {
 		Shorts shorts = checkShorts(shortsId);
-		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.getId().equals(shorts.getUser().getId())) {
+		if (!user.getUserRole().equals(UserRole.ROLE_ADMIN) && !user.equals(shorts.getUser())) {
 			throw new RestApiException(ErrorStatusCode.UNAVAILABLE_MODIFICATION);
 		}
 
@@ -86,8 +86,8 @@ public class ShortsService {
 
 	// 카테고리별 shorts 조회(페이징)
 	@Transactional(readOnly = true)
-	public List<ShortsDto.ResponseDto> getShortsByCategory(Category category, int page, int size, Long userId) {
-		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+	public List<ShortsDto.ResponseDto> getShortsByCategory(Category category, int page, Long userId) {
+		Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 		List<Shorts> shortsByCategory = shortsRepository.findShortsByIsDeletedFalseAndCategory(category, pageable).getContent();
 
 		List<ShortsDto.ResponseDto> shortsList = new ArrayList<>();
@@ -106,8 +106,8 @@ public class ShortsService {
 
 	// 메인화면에서 shorts 조회(페이징)
 	@Transactional(readOnly = true)
-	public List<ShortsDto.SimpleResponseDto> getSimpleShortsByCategory(Category category, int page, int size) {
-		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+	public List<ShortsDto.SimpleResponseDto> getSimpleShortsByCategory(Category category) {
+		Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 		List<Shorts> shortsByCategory = shortsRepository.findShortsByIsDeletedFalseAndCategory(category, pageable).getContent();
 
 		List<ShortsDto.SimpleResponseDto> shortsList = new ArrayList<>();


### PR DESCRIPTION
프론트와 회의를 통해 아래와 같은 변경사항이 생겼습니다.
  1. 쇼츠화면에서 보여줄 데이터의 1페이지당 사이즈를 10개로 고정
  2. 메인화면에서는 각 카테고리별로 최신의 데이터 10개만 보여주기로 결정
이에 따라 불필요한 requestParam(page, size)을 삭제하고, 로직를 수정하였습니다.