### PR TITLE
Fix: shortsRepository 수정

### DIFF
--- a/src/main/java/com/team1/spreet/repository/ShortsRepository.java
+++ b/src/main/java/com/team1/spreet/repository/ShortsRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ShortsRepository extends JpaRepository<Shorts, Long>, ShortsCustomRepository {
+public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 	@Query("select s from Shorts s where s.id = :shortsId and s.isDeleted = false")
 	Optional<Shorts> findByIdAndIsDeletedFalse(@Param("shortsId")Long shortsId);
 


### PR DESCRIPTION
queryDSL을 본격 적용하기 전인데, shortsRepository에서 customRepository를 상속하도록 해놓았었기 때문에 해당 부분 코드를 수정하였습니다.