### PR TITLE
Fix: 프로필 이미지 수정 예외처리, 작성일자 DateFormat 변경

### DIFF
--- a/src/main/java/com/team1/spreet/dto/UserDto.java
+++ b/src/main/java/com/team1/spreet/dto/UserDto.java
@@ -184,7 +184,7 @@ public class UserDto {
         private String category;
 
         @ApiModelProperty(value = "등록 일자")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd' 'hh:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd' 'HH:mm", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
 
         public PostResponseDto(String classification, Long id, String title, String category, LocalDateTime createdAt) {

--- a/src/main/java/com/team1/spreet/service/UserService.java
+++ b/src/main/java/com/team1/spreet/service/UserService.java
@@ -99,13 +99,13 @@ public class UserService {
     public void updateProfileImage(MultipartFile file, User user) {
         checkUser(user.getId());
 
-        //첨부파일 수정시 기존 첨부파일 삭제
-        String fileName = user.getProfileImage().split(".com/")[1];
-        awsS3Service.deleteFile(fileName);
-
-        //새로운 파일 업로드
-        String profileImage = awsS3Service.uploadFile(file);
-
+        String profileImage;
+        if (user.getProfileImage().contains("https://spreet")) {
+            //첨부파일 수정시 기존 첨부파일 삭제
+            String fileName = user.getProfileImage().split(".com/")[1];
+            awsS3Service.deleteFile(fileName);
+        }
+        profileImage = awsS3Service.uploadFile(file);
         user.updateProfileImage(profileImage);
         userRepository.saveAndFlush(user);
     }


### PR DESCRIPTION
1. 프로필 이지미 수정 기능 예외처리
 - s3에 저장하지 않는 카카오/네이버에서 받아온 이미지url인 경우의 예외처리
2. 회원 작성글 조회에서 반환하는 작성일자 DateFormat 변경
 - 12시간만 표시하도록 되어있어 24시간을 표현할 수 있도록 변경(09:27 -> 21:27)