### PR TITLE
Spreet 103 refactor alarm service with sse

### DIFF
--- a/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
@@ -1,9 +1,10 @@
 package com.team1.spreet.domain.subscribe.controller;
 
+import com.team1.spreet.domain.subscribe.dto.SubscribeDto;
+import com.team1.spreet.domain.subscribe.service.SubscribeService;
+import com.team1.spreet.global.auth.security.UserDetailsImpl;
 import com.team1.spreet.global.common.dto.CustomResponseBody;
 import com.team1.spreet.global.common.model.SuccessStatusCode;
-import com.team1.spreet.global.auth.security.UserDetailsImpl;
-import com.team1.spreet.domain.subscribe.service.SubscribeService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -16,16 +17,16 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/subscribe")
 public class SubscribeController {
     private final SubscribeService subscribeService;
-    @PostMapping("/{publisherNickname}")
-    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 ID") @PathVariable String publisherNickname,
+    @PostMapping
+    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 ID") @RequestBody SubscribeDto.RequestDto requestDto,
                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        subscribeService.subscribe(publisherNickname, userDetails.getUser());
+        subscribeService.subscribe(requestDto.getNickname(), userDetails.getUser());
         return new CustomResponseBody<>(SuccessStatusCode.SUBSCRIBE);
     }
-    @DeleteMapping("/{publisherNickname}")
-    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 ID") @PathVariable String  publisherNickname,
+    @DeleteMapping
+    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 ID") @RequestBody SubscribeDto.RequestDto requestDto,
                                                                  @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        subscribeService.cancelSubscribe(publisherNickname, userDetails.getUser());
+        subscribeService.cancelSubscribe(requestDto.getNickname(), userDetails.getUser());
         return new CustomResponseBody<>(SuccessStatusCode.CANCEL_SUBSCRIBE);
     }
 }

--- a/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
@@ -16,14 +16,16 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/subscribe")
 public class SubscribeController {
     private final SubscribeService subscribeService;
-    @PostMapping("/{publisherId}")
-    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 ID") @PathVariable Long publisherId,
+    @PostMapping("/{publisherNickname}")
+    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 ID") @PathVariable String publisherNickname,
                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return new CustomResponseBody<>(subscribeService.subscribe(publisherId, userDetails));
+        subscribeService.subscribe(publisherNickname, userDetails.getUser());
+        return new CustomResponseBody<>(SuccessStatusCode.SUBSCRIBE);
     }
-    @DeleteMapping("/{publisherId}")
-    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 ID") @PathVariable Long publisherId,
+    @DeleteMapping("/{publisherNickname}")
+    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 ID") @PathVariable String  publisherNickname,
                                                                  @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return new CustomResponseBody<>(subscribeService.cancelSubscribe(publisherId, userDetails));
+        subscribeService.cancelSubscribe(publisherNickname, userDetails.getUser());
+        return new CustomResponseBody<>(SuccessStatusCode.CANCEL_SUBSCRIBE);
     }
 }

--- a/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/controller/SubscribeController.java
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.*;
 public class SubscribeController {
     private final SubscribeService subscribeService;
     @PostMapping
-    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 ID") @RequestBody SubscribeDto.RequestDto requestDto,
+    public CustomResponseBody<SuccessStatusCode> subscribe(@ApiParam(value = "구독을 요청한 회원 nickname") @RequestBody SubscribeDto.RequestDto requestDto,
                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         subscribeService.subscribe(requestDto.getNickname(), userDetails.getUser());
         return new CustomResponseBody<>(SuccessStatusCode.SUBSCRIBE);
     }
     @DeleteMapping
-    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 ID") @RequestBody SubscribeDto.RequestDto requestDto,
+    public CustomResponseBody<SuccessStatusCode> cancelSubscribe(@ApiParam(value = "구독 취소를 요청한 회원 nickname") @RequestBody SubscribeDto.RequestDto requestDto,
                                                                  @AuthenticationPrincipal UserDetailsImpl userDetails) {
         subscribeService.cancelSubscribe(requestDto.getNickname(), userDetails.getUser());
         return new CustomResponseBody<>(SuccessStatusCode.CANCEL_SUBSCRIBE);

--- a/src/main/java/com/team1/spreet/domain/subscribe/dto/SubscribeDto.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/dto/SubscribeDto.java
@@ -1,0 +1,13 @@
+package com.team1.spreet.domain.subscribe.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SubscribeDto {
+    @NoArgsConstructor
+    @Getter
+    public static class RequestDto {
+
+        private String Nickname;
+    }
+}

--- a/src/main/java/com/team1/spreet/domain/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/repository/SubscribeRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     Optional<List<Subscribe>> findByPublisher(User publisher);
 
-    Subscribe findByPublisherAndSubscriber(User publisher, User subscriber);
+    void deleteByPublisherAndSubscriber(User publisher, User subscriber);
+
 }

--- a/src/main/java/com/team1/spreet/domain/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/team1/spreet/domain/subscribe/service/SubscribeService.java
@@ -1,13 +1,11 @@
 package com.team1.spreet.domain.subscribe.service;
 
 import com.team1.spreet.domain.subscribe.model.Subscribe;
-import com.team1.spreet.domain.user.model.User;
-import com.team1.spreet.global.error.model.ErrorStatusCode;
-import com.team1.spreet.global.error.exception.RestApiException;
-import com.team1.spreet.global.common.model.SuccessStatusCode;
 import com.team1.spreet.domain.subscribe.repository.SubscribeRepository;
+import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.repository.UserRepository;
-import com.team1.spreet.global.auth.security.UserDetailsImpl;
+import com.team1.spreet.global.error.exception.RestApiException;
+import com.team1.spreet.global.error.model.ErrorStatusCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,26 +15,18 @@ public class SubscribeService {
     private final SubscribeRepository subscribeRepository;
     private final UserRepository userRepository;
 
-    public SuccessStatusCode subscribe(Long publisherId, UserDetailsImpl userDetails) {
-        User publisher = userRepository.findById(publisherId).orElseThrow(
-                ()-> new RestApiException(ErrorStatusCode.NOT_EXIST_USER)
-        );
-        User subscriber = userRepository.findById(userDetails.getUser().getId()).orElseThrow(
-                ()-> new RestApiException(ErrorStatusCode.NOT_EXIST_USER)
-        );
+    public void subscribe(String publisherNickname, User subscriber) {
+        User publisher = checkUser(publisherNickname);
         Subscribe subscribe = new Subscribe(publisher, subscriber);
         subscribeRepository.save(subscribe);
-        return SuccessStatusCode.SUBSCRIBE;
     }
-    public SuccessStatusCode cancelSubscribe(Long publisherId, UserDetailsImpl userDetails) {
-        User publisher = userRepository.findById(publisherId).orElseThrow(
+    public void cancelSubscribe(String publisherNickname, User subscriber) {
+        User publisher = checkUser(publisherNickname);
+        subscribeRepository.deleteByPublisherAndSubscriber(publisher, subscriber);
+    }
+    private User checkUser(String userNickname){
+        return userRepository.findByNickname(userNickname).orElseThrow(
                 ()-> new RestApiException(ErrorStatusCode.NOT_EXIST_USER)
         );
-        User subscriber = userRepository.findById(userDetails.getUser().getId()).orElseThrow(
-                ()-> new RestApiException(ErrorStatusCode.NOT_EXIST_USER)
-        );
-        Subscribe subscribe = subscribeRepository.findByPublisherAndSubscriber(publisher, subscriber);
-        subscribeRepository.delete(subscribe);
-        return SuccessStatusCode.CANCEL_SUBSCRIBE;
     }
 }


### PR DESCRIPTION
1. 게시물에 작성자 id가 존재하지 않기 때문에 nickname을 기반으로 구독할 수 있도록 변환했습니다. nickname은 한글인 경우도 있기 때문에 requestbody로 받도록 dto를 새로 생성했습니다
2. 불필요한 로직과 DB접근을 최소화하고 공통된 부분은 메소드로 만들었습니다