### PR TITLE
Refactor: 소셜 로그인 예외처리

### DIFF
--- a/src/main/java/com/team1/spreet/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/team1/spreet/domain/user/service/KakaoLoginService.java
@@ -9,6 +9,8 @@ import com.team1.spreet.domain.user.model.UserRole;
 import com.team1.spreet.global.auth.jwt.JwtUtil;
 import com.team1.spreet.domain.user.repository.UserRepository;
 import com.team1.spreet.global.auth.security.UserDetailsImpl;
+import com.team1.spreet.global.error.exception.RestApiException;
+import com.team1.spreet.global.error.model.ErrorStatusCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -105,8 +107,16 @@ public class KakaoLoginService {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(responseBody);
         Long id = jsonNode.get("id").asLong();
-        String nickname = jsonNode.get("properties").get("nickname").asText();
         String email = jsonNode.get("kakao_account").get("email").asText();
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new RestApiException(ErrorStatusCode.OVERLAPPED_EMAIL);
+        }
+
+        String nickname = jsonNode.get("properties").get("nickname").asText();
+        if (userRepository.findByNickname(nickname).isPresent()) {
+            nickname = "kakao_" + email.split("@")[0];
+        }
+
         String profileImage = jsonNode.get("properties").get("profile_image").asText();
 
         return new UserDto.KakaoInfoDto(id, nickname, email, profileImage);

--- a/src/main/java/com/team1/spreet/domain/user/service/NaverLoginService.java
+++ b/src/main/java/com/team1/spreet/domain/user/service/NaverLoginService.java
@@ -121,7 +121,14 @@ public class NaverLoginService {
 
 		String id = jsonNode.get("response").get("id").asText();
 		String email = jsonNode.get("response").get("email").asText();
+		if (userRepository.findByEmail(email).isPresent()) {
+			throw new RestApiException(ErrorStatusCode.OVERLAPPED_EMAIL);
+		}
+
 		String nickname = jsonNode.get("response").get("nickname").asText();
+		if (userRepository.findByNickname(nickname).isPresent()) {
+			nickname = "naver_" + email.split("@")[0];
+		}
 
 		// 네이버에서 이미지 가져오기
 		String profileImage = jsonNode.get("response").get("profile_image").asText();


### PR DESCRIPTION
1. 이메일이 기존에 등록된 데이터와 중복될 경우 400에러 반환
2. 닉네임이 기존에 등록된 데이터와 중복될 경우 임의로 닉네임을 저장하여 회원가입되도록 함
  - ex) kakao_email(@ 앞의 주소)