### PR TITLE
Refactor: 유저 정보 확인하는 코드 리팩토링

### DIFF
--- a/src/main/java/com/team1/spreet/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/team1/spreet/domain/mypage/controller/MyPageController.java
@@ -2,7 +2,6 @@ package com.team1.spreet.domain.mypage.controller;
 
 import com.team1.spreet.domain.mypage.dto.MyPageDto;
 import com.team1.spreet.domain.mypage.service.MyPageService;
-import com.team1.spreet.global.auth.security.UserDetailsImpl;
 import com.team1.spreet.global.common.dto.CustomResponseBody;
 import com.team1.spreet.global.common.model.SuccessStatusCode;
 import io.swagger.annotations.ApiOperation;
@@ -10,7 +9,6 @@ import io.swagger.annotations.ApiParam;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,17 +28,16 @@ public class MyPageController {
 	// 마이페이지 회원정보 조회
 	@ApiOperation(value = "회원정보 조회 API")
 	@GetMapping
-	public CustomResponseBody<MyPageDto.UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		return new CustomResponseBody<>(SuccessStatusCode.GET_USER_INFO, myPageService.getUserInfo(userDetails.getUser()));
+	public CustomResponseBody<MyPageDto.UserInfoResponseDto> getUserInfo() {
+		return new CustomResponseBody<>(SuccessStatusCode.GET_USER_INFO, myPageService.getUserInfo());
 	}
 
 	// 프로필 사진 변경
 	@ApiOperation(value = "프로필 이미지 수정 API")
 	@PutMapping("/edit/profile-image")
 	public CustomResponseBody<SuccessStatusCode> updateProfileImage(
-		@RequestParam(value = "file") @Valid @ApiParam(value = "새로운 프로필 이미지") MultipartFile file,
-		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		myPageService.updateProfileImage(file, userDetails.getUser());
+		@RequestParam(value = "file") @Valid @ApiParam(value = "새로운 프로필 이미지") MultipartFile file) {
+		myPageService.updateProfileImage(file);
 		return new CustomResponseBody<>(SuccessStatusCode.UPDATE_USER_INFO);
 	}
 
@@ -48,9 +45,8 @@ public class MyPageController {
 	@ApiOperation(value = "닉네임 수정 API")
 	@PutMapping("/edit/nickname")
 	public CustomResponseBody<SuccessStatusCode> updateNickname(
-		@RequestBody @Valid @ApiParam(value = "새로운 닉네임") MyPageDto.NicknameRequestDto requestDto,
-		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		myPageService.updateNickname(requestDto, userDetails.getUser());
+		@RequestBody @Valid @ApiParam(value = "새로운 닉네임") MyPageDto.NicknameRequestDto requestDto) {
+		myPageService.updateNickname(requestDto);
 		return new CustomResponseBody<>(SuccessStatusCode.UPDATE_USER_INFO);
 	}
 
@@ -58,9 +54,8 @@ public class MyPageController {
 	@ApiOperation(value = "회원 비밀번호 수정 API")
 	@PutMapping("/edit/password")
 	public CustomResponseBody<SuccessStatusCode> updatePassword(
-		@RequestBody @Valid @ApiParam(value = "수정할 비밀번호") MyPageDto.PasswordRequestDto requestDto,
-		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		myPageService.updatePassword(requestDto, userDetails.getUser());
+		@RequestBody @Valid @ApiParam(value = "수정할 비밀번호") MyPageDto.PasswordRequestDto requestDto) {
+		myPageService.updatePassword(requestDto);
 		return new CustomResponseBody<>(SuccessStatusCode.UPDATE_PASSWORD);
 	}
 
@@ -68,9 +63,8 @@ public class MyPageController {
 	@ApiOperation(value = "비밀번호 변경시 인증을 위해 이메일 전송하는 API")
 	@PostMapping("/send-email")
 	public CustomResponseBody<SuccessStatusCode> sendConfirmEmail(
-		@RequestParam @ApiParam(value = "이메일 주소") String email,
-		@AuthenticationPrincipal UserDetailsImpl userDetails) throws Exception {
-		myPageService.sendConfirmEmail(email, userDetails.getUser());
+		@RequestParam @ApiParam(value = "이메일 주소") String email) throws Exception {
+		myPageService.sendConfirmEmail(email);
 		return new CustomResponseBody<>(SuccessStatusCode.EMAIL_SEND_SUCCESS);
 	}
 
@@ -79,10 +73,9 @@ public class MyPageController {
 	@GetMapping("/post")
 	public CustomResponseBody<List<MyPageDto.PostResponseDto>> getPostList (
 		@RequestParam(value = "classification") @ApiParam(value = "게시글 분류") String classification,
-		@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") Long page,
-		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		@RequestParam(value = "page") @ApiParam(value = "조회할 페이지") Long page) {
 		return new CustomResponseBody<>(SuccessStatusCode.GET_POST_LIST,
-			myPageService.getPostList(classification, page, userDetails.getUser()));
+			myPageService.getPostList(classification, page));
 	}
 
 }

--- a/src/main/java/com/team1/spreet/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/team1/spreet/domain/mypage/service/MyPageService.java
@@ -10,6 +10,7 @@ import com.team1.spreet.global.error.exception.RestApiException;
 import com.team1.spreet.global.error.model.ErrorStatusCode;
 import com.team1.spreet.global.infra.email.service.EmailService;
 import com.team1.spreet.global.infra.s3.service.AwsS3Service;
+import com.team1.spreet.global.util.SecurityUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -33,17 +34,22 @@ public class MyPageService {
 
 	// 회원 정보 조회
 	@Transactional(readOnly = true)
-	public MyPageDto.UserInfoResponseDto getUserInfo(User user) {
-		checkUser(user.getId());
+	public MyPageDto.UserInfoResponseDto getUserInfo() {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
 
 		return new MyPageDto.UserInfoResponseDto(user.getLoginId(), user.getNickname(),
 			user.getEmail(), user.getProfileImage());
 	}
 
 	// 프로필 사진 변경
-	public void updateProfileImage(MultipartFile file, User user) {
-		checkUser(user.getId());
-
+	public void updateProfileImage(MultipartFile file) {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
 		String profileImage;
 		if (user.getProfileImage().contains("https://spreet")) {
 			//첨부파일 수정시 기존 첨부파일 삭제
@@ -56,8 +62,11 @@ public class MyPageService {
 	}
 
 	// 닉네임 변경
-	public void updateNickname(MyPageDto.NicknameRequestDto requestDto, User user) {
-		checkUser(user.getId());
+	public void updateNickname(MyPageDto.NicknameRequestDto requestDto) {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
 
 		// 변경하려는 닉네임이 중복인 경우
 		if (userRepository.findByNickname(requestDto.getNickname()).isPresent()) {
@@ -68,8 +77,11 @@ public class MyPageService {
 	}
 
 	// 비밀번호 초기화(변경)
-	public void updatePassword(MyPageDto.PasswordRequestDto requestDto, User user) {
-		checkUser(user.getId());
+	public void updatePassword(MyPageDto.PasswordRequestDto requestDto) {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
 
 		// 기존과 동일한 비밀번호의 경우 에러처리
 		if (user.getPassword().equals(bcryptPasswordEncoder.encode(requestDto.getPassword()))) {
@@ -80,7 +92,12 @@ public class MyPageService {
 	}
 
 	// 비밀번호 변경시 인증 위해 이메일 전송
-	public void sendConfirmEmail(String email, User user) throws Exception {
+	public void sendConfirmEmail(String email) throws Exception {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
+
 		if (!email.equals(user.getEmail())) {
 			throw new RestApiException(ErrorStatusCode.MISMATCH_EMAIL);
 		}
@@ -89,8 +106,11 @@ public class MyPageService {
 
 	// 회원이 작성한 게시글 목록(쇼츠,피드,행사) 조회
 	@Transactional(readOnly = true)
-	public List<MyPageDto.PostResponseDto> getPostList(String classification, Long page, User user) {
-		checkUser(user.getId());
+	public List<MyPageDto.PostResponseDto> getPostList(String classification, Long page) {
+		User user = SecurityUtil.getCurrentUser();
+		if (user == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
 
 		// shorts
 		if (classification.equals("shorts")) {
@@ -107,12 +127,6 @@ public class MyPageService {
 			return eventRepository.findByUserId(classification, page - 1, user.getId());
 		}
 		return null;
-	}
-
-	private void checkUser(Long userId) {
-		if (userRepository.findByIdAndDeletedFalse(userId).isEmpty()) {
-			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
-		}
 	}
 
 }

--- a/src/main/java/com/team1/spreet/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/team1/spreet/global/config/WebSecurityConfig.java
@@ -91,6 +91,8 @@ public class WebSecurityConfig {
 
         config.addAllowedOrigin("http://localhost:3000");
 
+        config.addAllowedOrigin("https://spreet.co.kr/");
+
         config.addAllowedOrigin("https://dev.d2hev55rb01409.amplifyapp.com/");
 
         config.addExposedHeader(JwtUtil.AUTHORIZATION_HEADER);

--- a/src/main/java/com/team1/spreet/global/util/SecurityUtil.java
+++ b/src/main/java/com/team1/spreet/global/util/SecurityUtil.java
@@ -1,0 +1,29 @@
+package com.team1.spreet.global.util;
+
+import com.team1.spreet.domain.user.model.User;
+import com.team1.spreet.global.auth.security.UserDetailsImpl;
+import com.team1.spreet.global.error.exception.RestApiException;
+import com.team1.spreet.global.error.model.ErrorStatusCode;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@NoArgsConstructor
+public class SecurityUtil {
+
+	public static User getCurrentUser() {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null) {
+			throw new RestApiException(ErrorStatusCode.NOT_EXIST_USER);
+		}
+
+		if (authentication.getPrincipal() instanceof UserDetails) {
+			UserDetailsImpl springSecurityUser = (UserDetailsImpl) authentication.getPrincipal();
+			return springSecurityUser.getUser();
+		}else {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
유저 정보를 지금까지는 controller 단에서 @AuthenticationPrincipal 을 이용하여 가져오고 있었는데, SecurityUtil 클래스를 이용하여 SpringSecurityContextHolder에서 가져오도록 변경하였습니다.
  - 회원정보가 null 인 경우 500 에러가 발생하기 때문에, 예측 가능한 예외를 처리하기 위함
