### PR TITLE
Refactor: 회원가입 방법에 따라 회원정보 구별

### DIFF
--- a/src/main/java/com/team1/spreet/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/team1/spreet/domain/mypage/service/MyPageService.java
@@ -4,6 +4,7 @@ import com.team1.spreet.domain.event.repository.EventRepository;
 import com.team1.spreet.domain.feed.repository.FeedRepository;
 import com.team1.spreet.domain.mypage.dto.MyPageDto;
 import com.team1.spreet.domain.shorts.repository.ShortsRepository;
+import com.team1.spreet.domain.user.model.Provider;
 import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.repository.UserRepository;
 import com.team1.spreet.global.error.exception.RestApiException;
@@ -40,7 +41,16 @@ public class MyPageService {
 			throw new RestApiException(ErrorStatusCode.NOT_EXIST_AUTHORIZATION);
 		}
 
-		return new MyPageDto.UserInfoResponseDto(user.getLoginId(), user.getNickname(),
+		String loginId = user.getLoginId();
+		if (user.getProvider().equals(Provider.NAVER)) {
+			loginId = "네이버 로그인 이용중";
+		}
+
+		if (user.getProvider().equals(Provider.KAKAO)) {
+			loginId = "카카오 로그인 이용중";
+		}
+
+		return new MyPageDto.UserInfoResponseDto(loginId, user.getNickname(),
 			user.getEmail(), user.getProfileImage());
 	}
 

--- a/src/main/java/com/team1/spreet/domain/user/dto/UserDto.java
+++ b/src/main/java/com/team1/spreet/domain/user/dto/UserDto.java
@@ -1,5 +1,6 @@
 package com.team1.spreet.domain.user.dto;
 
+import com.team1.spreet.domain.user.model.Provider;
 import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.model.UserRole;
 import io.swagger.annotations.ApiModelProperty;
@@ -49,8 +50,9 @@ public class UserDto {
         @ApiModelProperty(value = "회원 권한", required = true)
         private UserRole userRole;
 
-        public User toEntity(String encodePassword) {
-            return new User(this.loginId, this.nickname, this.password = encodePassword, this.email, this.profileImage, this.userRole);
+        public User toEntity(String encodePassword, Provider provider) {
+            return new User(this.loginId, this.nickname, this.password = encodePassword,
+                this.email, this.profileImage, this.userRole, provider);
         }
     }
 

--- a/src/main/java/com/team1/spreet/domain/user/model/Provider.java
+++ b/src/main/java/com/team1/spreet/domain/user/model/Provider.java
@@ -1,0 +1,20 @@
+package com.team1.spreet.domain.user.model;
+
+import lombok.Getter;
+
+@Getter
+public enum Provider {
+    LOCAL("LOCAL"),
+    NAVER("NAVER"),
+    KAKAO("KAKAO");
+
+    private final String type;
+
+    Provider(String type) {
+        this.type = type;
+    }
+
+    public String value() {
+        return type;
+    }
+}

--- a/src/main/java/com/team1/spreet/domain/user/model/User.java
+++ b/src/main/java/com/team1/spreet/domain/user/model/User.java
@@ -39,19 +39,24 @@ public class User extends TimeStamped {
     private UserRole userRole;  //유저 권한
 
     @Column(nullable = false)
-    private boolean deleted;  //유저 탈퇴 여부, 기본값=FALSE
+    private boolean deleted = Boolean.FALSE;  //유저 탈퇴 여부, 기본값=FALSE
 
     @Column(nullable = false)
     private String profileImage;   //프로필 사진
 
-    public User(String loginId, String nickname, String password, String email, String profileImage, UserRole userRole) {
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;   // 어떻게 회원가입을 했는지
+
+    public User(String loginId, String nickname, String password, String email,
+        String profileImage, UserRole userRole, Provider provider) {
         this.loginId = loginId;
         this.nickname = nickname;
         this.password = password;
         this.email = email;
-        this.userRole = userRole;
-        this.deleted = Boolean.FALSE;
         this.profileImage = profileImage;
+        this.userRole = userRole;
+        this.provider = provider;
     }
 
     public void approveCrew() {

--- a/src/main/java/com/team1/spreet/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/team1/spreet/domain/user/service/KakaoLoginService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team1.spreet.domain.user.dto.UserDto;
+import com.team1.spreet.domain.user.model.Provider;
 import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.model.UserRole;
 import com.team1.spreet.domain.user.repository.UserRepository;
@@ -140,7 +141,7 @@ public class KakaoLoginService {
 			String profileImage = kakaoInfoDto.getProfileImage();
 
 			kakaoUser = new User(kakaoId, nickname, encodedPassword, kakaoEmail,
-				profileImage, UserRole.ROLE_USER);
+				profileImage, UserRole.ROLE_USER, Provider.KAKAO);
 
 			userRepository.save(kakaoUser);
 		}

--- a/src/main/java/com/team1/spreet/domain/user/service/NaverLoginService.java
+++ b/src/main/java/com/team1/spreet/domain/user/service/NaverLoginService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team1.spreet.domain.user.dto.UserDto;
+import com.team1.spreet.domain.user.model.Provider;
 import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.model.UserRole;
 import com.team1.spreet.domain.user.repository.UserRepository;
@@ -154,7 +155,7 @@ public class NaverLoginService {
 			String profileImage = naverInfoDto.getProfileImage();
 
 			naverUser = new User(naverId, nickname, encodedPassword, naverEmail,
-				profileImage, UserRole.ROLE_USER);
+				profileImage, UserRole.ROLE_USER, Provider.NAVER);
 
 			userRepository.save(naverUser);
 		}

--- a/src/main/java/com/team1/spreet/domain/user/service/UserService.java
+++ b/src/main/java/com/team1/spreet/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.team1.spreet.domain.user.service;
 
 import com.team1.spreet.domain.user.dto.UserDto;
+import com.team1.spreet.domain.user.model.Provider;
 import com.team1.spreet.domain.user.model.User;
 import com.team1.spreet.domain.user.model.UserRole;
 import com.team1.spreet.domain.user.repository.UserRepository;
@@ -43,7 +44,8 @@ public class UserService {
             throw new RestApiException(ErrorStatusCode.EMAIL_CONFIRM_EXCEPTION);
         }
 
-        userRepository.save(requestDto.toEntity(bcryptPasswordEncoder.encode(requestDto.getPassword())));
+        userRepository.save(requestDto.toEntity(
+            bcryptPasswordEncoder.encode(requestDto.getPassword()), Provider.LOCAL));
     }
 
     // 회원 탈퇴


### PR DESCRIPTION
소셜 로그인을 이용하는 경우, 로그인 아이디는 마이페이지에서 표시하지 않는 것이 좋겠다는 판단
1. 어떻게 회원가입을 했는지를 user 엔티티의 Provider 컬럼으로 관리
2. 소셜 로그인의 경우 마이페이지에 로그인 아이디 대신 소셜 로그인을 이용중이라는 것을 표시