### PR TITLE
Spreet 82 refactor event crud

### DIFF
--- a/src/main/java/com/team1/spreet/domain/event/model/EventComment.java
+++ b/src/main/java/com/team1/spreet/domain/event/model/EventComment.java
@@ -26,7 +26,7 @@ public class EventComment extends TimeStamped {
 	@Column(name = "EVENT_COMMENT_ID")
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@Column(nullable = false)


### PR DESCRIPTION
프론트에서 행사 게시글 댓글의 글자수 제한을 하고 있지 않으므로 content 컬럼의 타입을 "TEXT"로 설정